### PR TITLE
Fix getter labels for Date type

### DIFF
--- a/src/birl/time.gleam
+++ b/src/birl/time.gleam
@@ -16,7 +16,7 @@ pub opaque type DateTime {
 }
 
 pub type Date {
-  Date(day: Int, month: Int, year: Int)
+  Date(year: Int, month: Int, day: Int)
 }
 
 pub type Time {

--- a/test/birl_test.gleam
+++ b/test/birl_test.gleam
@@ -78,6 +78,41 @@ pub fn to_parts_test() {
   |> should.equal(offset)
 }
 
+pub fn get_date_accessor_test() {
+  let date_time =
+    time.from_iso8601(iso_datetime)
+    |> should.be_ok
+
+  let date =
+    date_time
+    |> time.get_date
+
+  date.year
+  |> should.equal(year)
+
+  date.month
+  |> should.equal(month)
+
+  date.day
+  |> should.equal(day)
+
+  let time =
+    date_time
+    |> time.get_time
+
+  time.hour
+  |> should.equal(hour)
+
+  time.minute
+  |> should.equal(minute)
+
+  time.second
+  |> should.equal(second)
+
+  time.milli_second
+  |> should.equal(milli_second)
+}
+
 pub fn from_parts_test() {
   time.unix_epoch
   |> time.set_offset(offset)


### PR DESCRIPTION
The labels for `year` and `day` were swapped, causing the respective getters to return the wrong values. I've added a test that detects the bug, and fixed it.