### PR TITLE
fix: Update to_parts JS ffi to use getUTCFullYear

### DIFF
--- a/src/birl_ffi.mjs
+++ b/src/birl_ffi.mjs
@@ -20,7 +20,7 @@ export function monotonic_now() {
 export function to_parts(timestamp, offset) {
   const date = new Date((timestamp + offset) / 1000);
   return [
-    [date.getFullYear(), date.getUTCMonth() + 1, date.getUTCDate()],
+    [date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate()],
     [
       date.getUTCHours(),
       date.getUTCMinutes(),


### PR DESCRIPTION
Fixes JS FFI `to_parts` to use getUTCFullYear, otherwise returns the wrong year for locations west of UTC.