### PR TITLE
fix for offset check when month or year changes

### DIFF
--- a/src/birl_ffi.erl
+++ b/src/birl_ffi.erl
@@ -34,11 +34,11 @@ now() -> os:system_time(microsecond).
 
 local_offset() ->
     Timestamp = erlang:timestamp(),
-    {{_, _, LD}, {LH, LM, _}} = calendar:now_to_local_time(Timestamp),
-    {{_, _, UD}, {UH, UM, _}} = calendar:now_to_universal_time(Timestamp),
+    {{LY, LN, LD}, {LH, LM, _}} = calendar:now_to_local_time(Timestamp),
+    {{UY, UN, UD}, {UH, UM, _}} = calendar:now_to_universal_time(Timestamp),
     if
         LD == UD -> (LH - UH) * 60 + LM - UM;
-        LD > UD -> (23 - UH) * 60 + (60 - UM) + LH * 60 + LM;
+        LD > UD orelse LN > UN orelse LY > UY -> (23 - UH) * 60 + (60 - UM) + LH * 60 + LM; 
         LD < UD -> -((23 - LH) * 60 + (60 - LM) + UH * 60 + UM)
     end.
 


### PR DESCRIPTION
If the local time is at the start of the day but the universal time is the previous day a month or year check is required.

Fix for https://github.com/massivefermion/birl/issues/16