### PR TITLE
Add failing test with iso8601 date format

### DIFF
--- a/test/birl_test.gleam
+++ b/test/birl_test.gleam
@@ -1,8 +1,9 @@
-import gleam/order
-import gleeunit
-import gleeunit/should
 import birl
 import birl/duration
+import gleam/order
+import gleam/result
+import gleeunit
+import gleeunit/should
 
 const iso_datetime = "1905-12-22T16:38:23.000+03:30"
 
@@ -184,4 +185,11 @@ pub fn weird_value8_test() {
   |> should.be_ok
   |> birl.to_naive
   |> should.equal("2019-03-26T14:00:00.020")
+}
+
+pub fn weird_value9_test() {
+  "2019-03-26"
+  |> birl.parse
+  |> result.map(birl.get_day)
+  |> should.equal(Ok(birl.Day(2019, 3, 26)))
 }


### PR DESCRIPTION
I found this confusing that it doesn't either parse correctly or error.

From the discord, our understanding it that the code is expecting some kind of valid offset in the value but YYYY-MM-DD is a valid iso8601 format, I believe (at least it is listed in the examples on https://en.wikipedia.org/wiki/ISO_8601.)

Imports reordered due to gleam 1.1 formatting.

I can make an effort at trying to change the code to handle this situation if that would be useful but I'm not familiar with the current logic so I might struggle to say inline with it appropriately. 

Hayleigh did point out that I can use `from_naive` to get the right result but, still, I think this should be handled differently here.