### PR TITLE
Add functions to get and create Time based on Unix timestamps with a millisecond or microsecond precision. 

### DIFF
--- a/src/birl.gleam
+++ b/src/birl.gleam
@@ -839,13 +839,13 @@ pub fn from_unix(value: Int) -> Time {
 /// unix milli timestamps are the number of milliseconds that have elapsed since 00:00:00 UTC on January 1st, 1970
 pub fn to_unix_milli(value: Time) -> Int {
   case value {
-    Time(t, _, _, _) -> t / 1_000
+    Time(t, _, _, _) -> t / 1000
   }
 }
 
 /// unix milli timestamps are the number of milliseconds that have elapsed since 00:00:00 UTC on January 1st, 1970
 pub fn from_unix_milli(value: Int) -> Time {
-  Time(value * 1_000, 0, option.None, option.None)
+  Time(value * 1000, 0, option.None, option.None)
 }
 
 /// unix micro timestamps are the number of microseconds that have elapsed since 00:00:00 UTC on January 1st, 1970

--- a/src/birl.gleam
+++ b/src/birl.gleam
@@ -816,6 +816,30 @@ pub fn from_unix(value: Int) -> Time {
   Time(value * 1_000_000, 0, option.None, option.None)
 }
 
+/// unix milli timestamps are the number of milliseconds that have elapsed since 00:00:00 UTC on January 1st, 1970
+pub fn to_unix_milli(value: Time) -> Int {
+  case value {
+    Time(t, _, _, _) -> t / 1_000
+  }
+}
+
+/// unix milli timestamps are the number of milliseconds that have elapsed since 00:00:00 UTC on January 1st, 1970
+pub fn from_unix_milli(value: Int) -> Time {
+  Time(value * 1_000, 0, option.None, option.None)
+}
+
+/// unix micro timestamps are the number of microseconds that have elapsed since 00:00:00 UTC on January 1st, 1970
+pub fn to_unix_micro(value: Time) -> Int {
+  case value {
+    Time(t, _, _, _) -> t
+  }
+}
+
+/// unix micro timestamps are the number of microseconds that have elapsed since 00:00:00 UTC on January 1st, 1970
+pub fn from_unix_micro(value: Int) -> Time {
+  Time(value, 0, option.None, option.None)
+}
+
 pub fn compare(a: Time, b: Time) -> order.Order {
   let Time(wall_time: wta, offset: _, timezone: _, monotonic_time: mta) = a
   let Time(wall_time: wtb, offset: _, timezone: _, monotonic_time: mtb) = b


### PR DESCRIPTION
This pull request adds the following public functions:
- `to_unix_milli(value: Time) -> Int`
- `from_unix_milli(value: Int) -> Time`
- `to_unix_micro(value: Time) -> Int`
- `from_unix_micro(value: Int) -> Time`


Those work exactly the same way as the existing ones:
- `to_unix(value: Time) -> Int`
- `from_unix(value: Int) -> Time`

with the difference beeing, that the precition is increased.

---

I added those functions because I want to store the current time as a Unix timestamp in a SQLite database with the highest precision possible for logging events. They also shouldn't have a high maintainability overhead since they are really simple. 