### PR TITLE
Set date from small to large time unit

### DIFF
--- a/src/birl_ffi.mjs
+++ b/src/birl_ffi.mjs
@@ -31,14 +31,16 @@ export function to_parts(timestamp, offset) {
 }
 
 export function from_parts(parts, offset) {
-  const date = new Date();
-  date.setUTCFullYear(parts[0][0]);
-  date.setUTCMonth(parts[0][1] - 1);
-  date.setUTCDate(parts[0][2]);
-  date.setUTCHours(parts[1][0]);
-  date.setUTCMinutes(parts[1][1]);
-  date.setUTCSeconds(parts[1][2]);
-  date.setUTCMilliseconds(parts[1][3]);
+  const date = new Date(Date.UTC(
+    parts[0][0],
+    parts[0][1] - 1,
+    parts[0][2],
+    parts[1][0],
+    parts[1][1],
+    parts[1][2],
+    parts[1][3],
+  ));
+
   return date.getTime() * 1000 - offset;
 }
 


### PR DESCRIPTION
This avoids ambiguous situations where the desired month does not have as many days at the current month, leading to unexpected behavior.

For example, intending to create a date in June on the 31st of May, will result in the date being in July instead:

```javascript
const date = new Date(); // May 31st, 2024
date.setUTCFullYear(2024); // Still May 31st, 2024
date.setUTCMonth(5); // No such thing as June 31st, sets to July 1st
```