### PR TITLE
Add helper function for determining if a Time has occured

### DIFF
--- a/src/birl.gleam
+++ b/src/birl.gleam
@@ -122,6 +122,11 @@ pub fn monotonic_now() -> Int {
   ffi_monotonic_now()
 }
 
+/// returns if the time has passed
+pub fn has_occured(value: Time) -> Bool {
+  compare(now(), value) == order.Gt
+}
+
 /// returns a string which is the date part of an ISO8601 string along with the offset
 pub fn to_date_string(value: Time) -> String {
   let #(#(year, month, day), _, offset) = to_parts(value)


### PR DESCRIPTION
This pull request adds `has_occured(value: Time) -> Bool`

---

I've added this as I find myself having to check this condition alot when dealing with JWT's or invalidation, and this shorthand removes my need for a helper function across my code. This function only calls the compare method and performs a comparison so basically no maintenence