### PR TITLE
Fix deprecation warnings in gleam_stdlib 0.44

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -10,7 +10,8 @@ links = [{ title = "Gleam", href = "https://gleam.run" }]
 
 [dependencies]
 ranger = ">= 1.2.0 and < 2.0.0"
-gleam_stdlib = ">= 0.43.0 and < 2.0.0"
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.2.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.43.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "69EF22E78FDCA9097CBE7DF91C05B2A8B5436826D9F66680D879182C0860A747" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
+  { name = "gleam_stdlib", version = "0.44.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "A6E55E309A6778206AAD4038D9C49E15DF71027A1DB13C6ADA06BFDB6CF1260E" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
-  { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
+  { name = "ranger", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "B8F3AFF23A3A5B5D9526B8D18E7C43A7DFD3902B151B97EC65397FE29192B695" },
 ]
 
 [requirements]
-gleam_stdlib = { version = ">= 0.43.0 and < 2.0.0" }
+gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.2.0 and < 2.0.0" }
 ranger = { version = ">= 1.2.0 and < 2.0.0" }

--- a/src/birl/duration.gleam
+++ b/src/birl/duration.gleam
@@ -2,7 +2,7 @@ import gleam/int
 import gleam/list
 import gleam/option
 import gleam/order
-import gleam/regex
+import gleam/regexp
 import gleam/result
 import gleam/string
 
@@ -316,7 +316,7 @@ const units = [
 /// numbers with no unit are considered as microseconds.
 /// specifying `accurate:` is equivalent to using `accurate_new`.
 pub fn parse(expression: String) -> Result(Duration, Nil) {
-  let assert Ok(re) = regex.from_string("([+|\\-])?\\s*(\\d+)\\s*(\\w+)?")
+  let assert Ok(re) = regexp.from_string("([+|\\-])?\\s*(\\d+)\\s*(\\w+)?")
 
   let #(constructor, expression) = case
     string.starts_with(expression, "accurate:")
@@ -331,10 +331,10 @@ pub fn parse(expression: String) -> Result(Duration, Nil) {
   case
     expression
     |> string.lowercase
-    |> regex.scan(re, _)
+    |> regexp.scan(re, _)
     |> list.try_map(fn(item) {
       case item {
-        regex.Match(_, [sign_option, option.Some(amount_string)]) -> {
+        regexp.Match(_, [sign_option, option.Some(amount_string)]) -> {
           use amount <- result.then(int.parse(amount_string))
 
           case sign_option {
@@ -344,7 +344,7 @@ pub fn parse(expression: String) -> Result(Duration, Nil) {
           }
         }
 
-        regex.Match(
+        regexp.Match(
           _,
           [sign_option, option.Some(amount_string), option.Some(unit)],
         ) -> {


### PR DESCRIPTION
Switches to the standalone `gleam_regexp` package because `gleam/regex` in the standard library was deprecated in v0.44.

There are still a couple of deprecations from the use of `gleam/iterator`, which was also deprecated. Fixing these warnings needs a new release of `ranger` to be made as mentioned [here](https://github.com/massivefermion/ranger/pull/1#issuecomment-2510247314).

I'll leave this PR as a draft until that release is available and the new version brought in.

Thanks.