### PR TITLE
fix #33 monotonic_now() to be OS agnostic

### DIFF
--- a/src/birl_ffi.erl
+++ b/src/birl_ffi.erl
@@ -78,7 +78,8 @@ local_timezone() ->
 monotonic_now() ->
     StartTime = erlang:system_info(start_time),
     CurrentTime = erlang:monotonic_time(),
-    (CurrentTime - StartTime) div 1_000.
+    Difference = (CurrentTime - StartTime),
+    erlang:convert_time_unit(Difference, native, microsecond).
 
 to_parts(Timestamp, Offset) ->
     {Date, {Hour, Minute, Second}} = calendar:system_time_to_universal_time(


### PR DESCRIPTION
fix #33 

Dividing by 1000 only works when the OS's native time is in nanoseconds. Using erlang:convert_time_unit/3 should work on all platforms.